### PR TITLE
fix: add missing typescript peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   "name": "tsutils-etc",
   "optionalDependencies": {},
   "peerDependencies": {
-    "tsutils": "^3.0.0"
+    "tsutils": "^3.0.0",
+    "typescript": "^4.0.0"
   },
   "private": false,
   "publishConfig": {


### PR DESCRIPTION
Hi @cartant 👋 

I've come across at least one case in `tsutils-etc` where values from typescript are being used rather than types only.
https://github.com/cartant/tsutils-etc/blob/master/source/could-be-function.ts#L14

When using strict node linkers like pnp or pnpm this results in `tsutils-etc` not being able to load typescript as it isn't declared as a dependency.

I've added typescript as a peer dependency, and set it to the same version that is required in `eslint-plugin-rxjs`.